### PR TITLE
Add standard Next.js .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+node_modules/
+
+# Next.js build output
+.next/
+
+# Log files
+*.log


### PR DESCRIPTION
## Summary
- add `.gitignore` at repository root to ignore Node modules, Next.js build output, and log files

## Testing
- `git status --short`